### PR TITLE
Proposal - Remove the ambiguous overloading of the "log" method

### DIFF
--- a/opslogger-support/src/main/java/com/equalexperts/logging/OpsLoggerTestDouble.java
+++ b/opslogger-support/src/main/java/com/equalexperts/logging/OpsLoggerTestDouble.java
@@ -47,7 +47,7 @@ public class OpsLoggerTestDouble <T extends Enum<T> & LogMessage> implements Ops
     }
 
     @Override
-    public void log(T message, Throwable cause, Object... details) {
+    public void logThrowable(T message, Throwable cause, Object... details) {
         validate(message);
         ensureImmutableDetails(details);
         assertNotNull("Throwable instance must be provided", cause);

--- a/opslogger-support/src/test/java/com/equalexperts/logging/OpsLoggerTestDoubleTest.java
+++ b/opslogger-support/src/test/java/com/equalexperts/logging/OpsLoggerTestDoubleTest.java
@@ -126,7 +126,7 @@ public class OpsLoggerTestDoubleTest {
             assertThat(e.getMessage(), containsString("MessagePattern must be provided"));
         }
     }
-    
+
     @Test
     public void log_shouldThrowAnException_givenAMutableFormatStringArgument() throws Exception {
         try {
@@ -150,17 +150,17 @@ public class OpsLoggerTestDoubleTest {
 
     //endregion
 
-    //region tests for log(Message, Throwable, Object...)
+    //region tests for logThrowable(Message, Throwable, Object...)
 
     @Test
     public void log_shouldAllowValidCalls_givenAThrowable() throws Exception {
-        logger.log(TestMessages.Foo, new RuntimeException());
+        logger.logThrowable(TestMessages.Foo, new RuntimeException());
     }
 
     @Test
     public void log_shouldThrowAnException_givenAnInvalidFormatStringWithTheRightArgumentsAndAThrowable() throws Exception {
         try {
-            logger.log(TestMessages.BadFormatString, new RuntimeException(), 42);
+            logger.logThrowable(TestMessages.BadFormatString, new RuntimeException(), 42);
             fail("expected an exception");
         } catch (IllegalFormatException e) {
             //this exception is expected
@@ -171,7 +171,7 @@ public class OpsLoggerTestDoubleTest {
     public void log_shouldThrowAnException_givenNotEnoughFormatStringArgumentsAndAThrowable() throws Exception {
 
         try {
-            logger.log(TestMessages.Bar, new RuntimeException());
+            logger.logThrowable(TestMessages.Bar, new RuntimeException());
             fail("expected an exception");
         } catch (IllegalFormatException e) {
             //this exception is expected
@@ -182,7 +182,7 @@ public class OpsLoggerTestDoubleTest {
     public void log_shouldThrowAnException_givenTooManyFormatStringArgumentsAndAThrowable() throws Exception {
 
         try {
-            logger.log(TestMessages.Bar, new RuntimeException(), "Foo", "Bar");
+            logger.logThrowable(TestMessages.Bar, new RuntimeException(), "Foo", "Bar");
             fail("expected an exception");
         } catch (IllegalArgumentException e) {
             //this exception is expected
@@ -192,13 +192,13 @@ public class OpsLoggerTestDoubleTest {
 
     @Test
     public void log_shouldAllowCorrectLogMessages_givenTwoOrMoreFormatStringArgumentsAndThrowable() throws Exception {
-        logger.log(TestMessages.MessageWithMultipleArguments, new RuntimeException(), "Foo", "Bar");
+        logger.logThrowable(TestMessages.MessageWithMultipleArguments, new RuntimeException(), "Foo", "Bar");
     }
 
     @Test
     public void log_shouldThrowAnException_givenANullLogMessageAndThrowable() throws Exception {
         try {
-            logger.log(null, new RuntimeException());
+            logger.logThrowable(null, new RuntimeException());
             fail("expected an exception");
         } catch (AssertionError e) {
             assertThat(e.getMessage(), containsString("LogMessage must be provided"));
@@ -208,7 +208,7 @@ public class OpsLoggerTestDoubleTest {
     @Test
     public void log_shouldThrowAnException_givenANullThrowable() throws Exception {
         try {
-            logger.log(TestMessages.Bar, null, "a");
+            logger.logThrowable(TestMessages.Bar, null, "a");
             fail("expected an exception");
         } catch (AssertionError e) {
             assertThat(e.getMessage(), containsString("Throwable instance must be provided"));
@@ -218,7 +218,7 @@ public class OpsLoggerTestDoubleTest {
     @Test
     public void log_shouldThrowAnException_givenAThrowableAndNullMessageCode() throws Exception {
         try {
-            logger.log(TestMessages.InvalidNullCode, new RuntimeException());
+            logger.logThrowable(TestMessages.InvalidNullCode, new RuntimeException());
             fail("expected an exception");
         } catch (AssertionError e) {
             assertThat(e.getMessage(), containsString("MessageCode must be provided"));
@@ -228,7 +228,7 @@ public class OpsLoggerTestDoubleTest {
     @Test
     public void log_shouldThrowAnException_givenAThrowableAndAnEmptyMessageCode() throws Exception {
         try {
-            logger.log(TestMessages.InvalidEmptyCode, new RuntimeException());
+            logger.logThrowable(TestMessages.InvalidEmptyCode, new RuntimeException());
             fail("expected an exception");
         } catch (AssertionError e) {
             assertThat(e.getMessage(), containsString("MessageCode must be provided"));
@@ -238,7 +238,7 @@ public class OpsLoggerTestDoubleTest {
     @Test
     public void log_shouldThrowAnException_givenAThrowableAndNullMessageFormat() throws Exception {
         try {
-            logger.log(TestMessages.InvalidNullFormat, new RuntimeException());
+            logger.logThrowable(TestMessages.InvalidNullFormat, new RuntimeException());
             fail("expected an exception");
         } catch (AssertionError e) {
             assertThat(e.getMessage(), containsString("MessagePattern must be provided"));
@@ -248,7 +248,7 @@ public class OpsLoggerTestDoubleTest {
     @Test
     public void log_shouldThrowAnException_givenAThrowableAndAnEmptyMessageFormat() throws Exception {
         try {
-            logger.log(TestMessages.InvalidEmptyFormat, new RuntimeException());
+            logger.logThrowable(TestMessages.InvalidEmptyFormat, new RuntimeException());
             fail("expected an exception");
         } catch (AssertionError e) {
             assertThat(e.getMessage(), containsString("MessagePattern must be provided"));
@@ -258,7 +258,7 @@ public class OpsLoggerTestDoubleTest {
     @Test
     public void log_shouldThrowAnException_givenAThrowableAndAMutableFormatStringArgument() throws Exception {
         try {
-            logger.log(TestMessages.MessageWithMultipleArguments, new RuntimeException(), "foo", new StringBuilder("bar"));
+            logger.logThrowable(TestMessages.MessageWithMultipleArguments, new RuntimeException(), "foo", new StringBuilder("bar"));
             fail("expected an exception");
         } catch (MutabilityAssertionError e) {
             assertThat(e.getMessage(), containsString("StringBuilder"));
@@ -271,9 +271,9 @@ public class OpsLoggerTestDoubleTest {
         OpsLogger<TestMessages> logger = spy(this.logger);
         RuntimeException ex = new RuntimeException();
 
-        logger.log(TestMessages.Foo, ex);
+        logger.logThrowable(TestMessages.Foo, ex);
 
-        verify(logger).log(TestMessages.Foo, ex);
+        verify(logger).logThrowable(TestMessages.Foo, ex);
         verifyNoMoreInteractions(logger);
     }
 

--- a/opslogger/src/main/java/com/equalexperts/logging/OpsLogger.java
+++ b/opslogger/src/main/java/com/equalexperts/logging/OpsLogger.java
@@ -24,7 +24,7 @@ public interface OpsLogger<T extends Enum<T> & LogMessage> extends AutoCloseable
      * @param cause stack trace to process and include in the log message
      * @param details format string arguments to message.getMessagePattern()
      */
-    void log(T message, Throwable cause, Object... details);
+    void logThrowable(T message, Throwable cause, Object... details);
 
     /**
      * Create a nested logger that uses a local DiagnosticContextSupplier, which is often

--- a/opslogger/src/main/java/com/equalexperts/logging/impl/AsyncOpsLogger.java
+++ b/opslogger/src/main/java/com/equalexperts/logging/impl/AsyncOpsLogger.java
@@ -65,7 +65,7 @@ public class AsyncOpsLogger<T extends Enum<T> & LogMessage> implements OpsLogger
     }
 
     @Override
-    public void log(T message, Throwable cause, Object... details) {
+    public void logThrowable(T message, Throwable cause, Object... details) {
         try {
             DiagnosticContext diagnosticContext = new DiagnosticContext(diagnosticContextSupplier);
             LogicalLogRecord<T> record = new LogicalLogRecord<>(clock.instant(), diagnosticContext, message, Optional.of(cause), details);

--- a/opslogger/src/main/java/com/equalexperts/logging/impl/BasicOpsLogger.java
+++ b/opslogger/src/main/java/com/equalexperts/logging/impl/BasicOpsLogger.java
@@ -51,7 +51,7 @@ public class BasicOpsLogger<T extends Enum<T> & LogMessage> implements OpsLogger
     }
 
     @Override
-    public void log(T message, Throwable cause, Object... details) {
+    public void logThrowable(T message, Throwable cause, Object... details) {
         try {
             LogicalLogRecord<T> record = constructLogRecord(message, Optional.of(cause), details);
             publish(record);

--- a/opslogger/src/test/java/com/equalexperts/logging/impl/AsyncOpsLoggerTest.java
+++ b/opslogger/src/test/java/com/equalexperts/logging/impl/AsyncOpsLoggerTest.java
@@ -122,7 +122,7 @@ public class AsyncOpsLoggerTest {
 
         doNothing().when(transferQueue).put(captor.capture());
 
-        logger.log(TestMessages.Bar, expectedCause, 64, "Hello, World");
+        logger.logThrowable(TestMessages.Bar, expectedCause, 64, "Hello, World");
 
         verify(transferQueue).put(captor.capture());
 
@@ -138,7 +138,7 @@ public class AsyncOpsLoggerTest {
 
     @Test
     public void log_shouldExposeAnExceptionToTheHandler_givenAProblemCreatingTheLogRecordAndAThrowable() throws Exception {
-        logger.log(null, new RuntimeException());
+        logger.logThrowable(null, new RuntimeException());
 
         verify(exceptionConsumer).accept(Mockito.isA(NullPointerException.class));
     }
@@ -148,7 +148,7 @@ public class AsyncOpsLoggerTest {
         Error expectedThrowable = new Error();
         when(diagnosticContextSupplier.getMessageContext()).thenThrow(expectedThrowable);
 
-        logger.log(TestMessages.Foo, new RuntimeException());
+        logger.logThrowable(TestMessages.Foo, new RuntimeException());
 
         verify(exceptionConsumer).accept(Mockito.same(expectedThrowable));
     }
@@ -158,7 +158,7 @@ public class AsyncOpsLoggerTest {
         RuntimeException expectedThrowable = new RuntimeException("blah");
         doThrow(expectedThrowable).when(transferQueue).put(any());
 
-        logger.log(TestMessages.Foo, new Exception());
+        logger.logThrowable(TestMessages.Foo, new Exception());
 
         verify(exceptionConsumer).accept(Mockito.same(expectedThrowable));
     }

--- a/opslogger/src/test/java/com/equalexperts/logging/impl/BasicOpsLoggerTest.java
+++ b/opslogger/src/test/java/com/equalexperts/logging/impl/BasicOpsLoggerTest.java
@@ -141,7 +141,7 @@ public class BasicOpsLoggerTest {
         doNothing().when(destination).publish(captor.capture());
         RuntimeException expectedException = new RuntimeException("expected");
 
-        logger.log(TestMessages.Bar, expectedException, 64, "Hello, World");
+        logger.logThrowable(TestMessages.Bar, expectedException, 64, "Hello, World");
 
         verify(destination, times(1)).publish(any());
         verify(diagnosticContextSupplier).getMessageContext();
@@ -158,7 +158,7 @@ public class BasicOpsLoggerTest {
 
     @Test
     public void log_shouldObtainAndReleaseALockAndBeginAndEndADestinationBatch_givenALogMessageInstanceAndAThrowable() throws Exception {
-        logger.log(TestMessages.Foo, new RuntimeException());
+        logger.logThrowable(TestMessages.Foo, new RuntimeException());
 
         InOrder inOrder = inOrder(lock, destination);
         inOrder.verify(lock).lock();
@@ -170,14 +170,14 @@ public class BasicOpsLoggerTest {
 
     @Test
     public void log_shouldExposeAnExceptionToTheHandler_givenAProblemCreatingTheLogRecordWithAThrowable() throws Exception {
-        logger.log(TestMessages.Foo, (Throwable) null);
+        logger.logThrowable(TestMessages.Foo, null);
 
         verify(exceptionConsumer).accept(Mockito.isA(NullPointerException.class));
     }
 
     @Test
     public void log_shouldNotObtainALockOrInteractWithTheDestination_givenAProblemCreatingTheLogRecordWithAThrowable() throws Exception {
-        logger.log(null, new Throwable());
+        logger.logThrowable(null, new Throwable());
 
         verifyZeroInteractions(lock, destination);
     }
@@ -187,7 +187,7 @@ public class BasicOpsLoggerTest {
         Exception expectedException = new IOException("Couldn't write to the output stream");
         doThrow(expectedException).when(destination).publish(any());
 
-        logger.log(TestMessages.Foo, new NullPointerException());
+        logger.logThrowable(TestMessages.Foo, new NullPointerException());
 
         verify(exceptionConsumer).accept(Mockito.same(expectedException));
     }
@@ -196,7 +196,7 @@ public class BasicOpsLoggerTest {
     public void log_shouldEndTheBatchAndReleaseTheLock_givenAProblemPublishingTheLogRecordWithAThrowable() throws Exception {
         doThrow(new RuntimeException()).when(destination).publish(any());
 
-        logger.log(TestMessages.Foo, new Error());
+        logger.logThrowable(TestMessages.Foo, new Error());
 
         InOrder inOrder = inOrder(lock, destination);
         inOrder.verify(lock).lock();
@@ -211,7 +211,7 @@ public class BasicOpsLoggerTest {
         Error expectedThrowable = new Error();
         when(diagnosticContextSupplier.getMessageContext()).thenThrow(expectedThrowable);
 
-        logger.log(TestMessages.Foo, new RuntimeException());
+        logger.logThrowable(TestMessages.Foo, new RuntimeException());
 
         verify(exceptionConsumer).accept(Mockito.same(expectedThrowable));
     }
@@ -220,7 +220,7 @@ public class BasicOpsLoggerTest {
     public void log_shouldNotObtainALockOrInteractWithTheDestination_givenAProblemObtainingCorrelationIdsWithAThrowable() throws Exception {
         when(diagnosticContextSupplier.getMessageContext()).thenThrow(new RuntimeException());
 
-        logger.log(TestMessages.Foo, new Exception());
+        logger.logThrowable(TestMessages.Foo, new Exception());
 
         verifyZeroInteractions(lock, destination);
     }

--- a/sample-usage/src/main/java/uk/gov/gds/performance/collector/ClassThatLogs.java
+++ b/sample-usage/src/main/java/uk/gov/gds/performance/collector/ClassThatLogs.java
@@ -24,7 +24,7 @@ public class ClassThatLogs {
 
     public void bar() {
         RuntimeException e = new RuntimeException();
-        logger.log(UNKNOWN_ERROR, e);
+        logger.logThrowable(UNKNOWN_ERROR, e);
         throw e;
     }
 

--- a/sample-usage/src/test/java/uk/gov/gds/performance/collector/ClassThatLogsTest.java
+++ b/sample-usage/src/test/java/uk/gov/gds/performance/collector/ClassThatLogsTest.java
@@ -26,7 +26,7 @@ public class ClassThatLogsTest {
             theClass.bar();
             fail("expected an exception");
         } catch (RuntimeException e) {
-            verify(mockLogger).log(CollectorLogMessages.UNKNOWN_ERROR, e);
+            verify(mockLogger).logThrowable(CollectorLogMessages.UNKNOWN_ERROR, e);
         }
     }
 


### PR DESCRIPTION
OpsLogger has ambiguously overloaded 'log' methods. This might seem not to be a problem because the Java compiler picks the best match. However, there are two possible pitfalls:

* it might lead to mistakes due to developers being confused, putting parameters in the wrong order etc
* it might cause compiler issues, especially with other JVM languages (e.g. Scala has different resolution rules to Java and sometimes gives compiler errors in cases that Java doesn't)

The solution offered here is to remove the ambiguous overloaded "log" method by renaming one to "logThrowable" instead.